### PR TITLE
feat: add chat-scoped document ingestion, logging, and Office file su…

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -5,8 +5,56 @@ on:
     types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
-  claude-review:
+  pytest:
+    name: pytest + coverage
     runs-on: ubuntu-latest
+    outputs:
+      coverage_report: ${{ steps.coverage.outputs.report }}
+      tests_passed: ${{ steps.coverage.outputs.passed }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run pytest with coverage
+        id: coverage
+        run: |
+          set +e
+          uv run pytest \
+            --cov=api \
+            --cov=ingestion \
+            --cov=shared \
+            --cov-report=term-missing \
+            --tb=short \
+            -q 2>&1 | tee pytest_output.txt
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "passed=true" >> $GITHUB_OUTPUT
+          else
+            echo "passed=false" >> $GITHUB_OUTPUT
+          fi
+
+          echo "report<<EOF" >> $GITHUB_OUTPUT
+          cat pytest_output.txt >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+  claude-review:
+    name: Claude Code Review
+    runs-on: ubuntu-latest
+    needs: pytest
     permissions:
       contents: read
       pull-requests: write
@@ -16,8 +64,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -50,6 +96,14 @@ jobs:
           direct_prompt: |
             You are a senior software engineer performing a thorough code review.
 
+            ## Test Results
+
+            **Tests passed:** ${{ needs.pytest.outputs.tests_passed }}
+
+            ```
+            ${{ needs.pytest.outputs.coverage_report }}
+            ```
+
             ## Linter Results
 
             ### flake8
@@ -62,14 +116,14 @@ jobs:
 
             ## Review Checklist
 
-            Use the linter output above as context, then review the PR diff for:
+            Use the test results, coverage report, and linter output above as context, then review the PR diff for:
 
             1. **Correctness** – Does the logic work as intended? Edge cases or bugs?
             2. **Code quality** – Readable, well-structured, consistent with the codebase?
-            3. **Linter violations** – Flag any issues from flake8/pylint that are non-trivial or indicate real problems. Skip pure style noise.
-            4. **Security** – Injection risks, exposed secrets, unsafe inputs, auth issues?
-            5. **Performance** – Obvious inefficiencies, unnecessary computation?
-            6. **Tests** – Are changes covered? Are existing tests still valid?
+            3. **Test coverage** – Are new/changed code paths covered? Flag any gaps in coverage shown above.
+            4. **Linter violations** – Flag any issues from flake8/pylint that are non-trivial or indicate real problems. Skip pure style noise.
+            5. **Security** – Injection risks, exposed secrets, unsafe inputs, auth issues?
+            6. **Performance** – Obvious inefficiencies, unnecessary computation?
             7. **Breaking changes** – Does this break existing interfaces or contracts?
 
             Be direct and specific. Point to exact lines when possible.

--- a/api/main.py
+++ b/api/main.py
@@ -1,12 +1,21 @@
 # api/main.py
 """FastAPI application entry point."""
 
+import logging
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from api.routes.health import router as health_router
 from api.routes.chat import router as chat_router
 from api.routes.ingest import router as ingest_router
+from shared.config import API_URL, EMBEDDING_PROVIDER, QDRANT_COLLECTION, QDRANT_URL
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 app = FastAPI(
     title="Custom RAG API",
@@ -28,6 +37,14 @@ app.include_router(health_router, tags=["health"])
 app.include_router(chat_router, prefix="/chat", tags=["chat"])
 app.include_router(ingest_router, prefix="/ingest", tags=["ingest"])
 
+
+logger.info(
+    "Custom RAG API starting — API_URL=%s QDRANT_URL=%s QDRANT_COLLECTION=%s EMBEDDING_PROVIDER=%s",
+    API_URL,
+    QDRANT_URL,
+    QDRANT_COLLECTION,
+    EMBEDDING_PROVIDER,
+)
 
 if __name__ == "__main__":
     import uvicorn

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -1,12 +1,15 @@
 # api/routes/chat.py
 """Chat endpoint — accepts a user query, runs the RAG pipeline, returns an answer."""
 
+import logging
+
 from fastapi import APIRouter, HTTPException
 
 from api.services.llm import generate_answer
 from api.services.retriever import retrieve
 from shared.models import ChatRequest, ChatResponse
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
@@ -18,9 +21,19 @@ async def chat(request: ChatRequest) -> ChatResponse:
     2. Build a prompt with retrieved context and call the LLM.
     3. Return the answer along with source chunks for citation.
     """
+    logger.info(
+        "Chat request received — query=%r model=%s top_k=%d chat_id=%s",
+        request.query[:100],
+        request.model,
+        request.top_k,
+        request.chat_id,
+    )
+
     try:
-        chunks = await retrieve(request.query, request.top_k)
-    except Exception:
+        chunks = await retrieve(request.query, request.top_k, chat_id=request.chat_id)
+        logger.info("Retrieval complete — chunks_returned=%d", len(chunks))
+    except Exception as exc:
+        logger.warning("Retrieval failed, proceeding without context — error=%s", exc)
         chunks = []
 
     try:
@@ -32,7 +45,9 @@ async def chat(request: ChatRequest) -> ChatResponse:
             api_key=request.api_key,
             api_url=request.api_url,
         )
+        logger.info("Generation complete — answer_length=%d", len(answer))
     except Exception as exc:
+        logger.error("LLM generation failed — error=%s", exc)
         raise HTTPException(status_code=502, detail=f"LLM generation failed: {exc}") from exc
 
     return ChatResponse(answer=answer, sources=chunks, model=request.model)

--- a/api/routes/ingest.py
+++ b/api/routes/ingest.py
@@ -1,6 +1,7 @@
 # api/routes/ingest.py
 """Ingest endpoint — accepts a document upload, chunks it, and stores embeddings."""
 
+import logging
 import tempfile
 from pathlib import Path
 
@@ -11,6 +12,7 @@ from ingestion.embedder import embed_chunks, upsert_to_store
 from ingestion.loader import load_document
 from shared.models import IngestResponse
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
@@ -18,6 +20,7 @@ router = APIRouter()
 async def ingest(
     file: UploadFile = File(..., description="Document file to ingest"),
     document_id: str = Form(..., description="Caller-supplied document identifier"),
+    chat_id: str = Form(default="", description="Chat session ID to scope this document to"),
 ) -> IngestResponse:
     """Ingest a document: load, chunk, embed, and store.
 
@@ -31,9 +34,17 @@ async def ingest(
     # strategy (PDF vs text).
     suffix = Path(file.filename or "upload.txt").suffix or ".txt"
 
+    logger.info(
+        "Ingest request received — filename=%s document_id=%s chat_id=%s",
+        file.filename,
+        document_id,
+        chat_id,
+    )
+
     try:
         file_bytes = await file.read()
     except Exception as exc:
+        logger.error("Failed to read uploaded file — error=%s", exc)
         raise HTTPException(status_code=400, detail=f"Could not read uploaded file: {exc}") from exc
 
     try:
@@ -41,16 +52,23 @@ async def ingest(
             tmp.write(file_bytes)
             tmp.flush()
             text = load_document(Path(tmp.name))
+        logger.info("Document loaded — text_length=%d", len(text))
     except ValueError as exc:
+        logger.error("Unsupported file type — error=%s", exc)
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except Exception as exc:
+        logger.error("Failed to load document — error=%s", exc)
         raise HTTPException(status_code=500, detail=f"Failed to load document: {exc}") from exc
 
     try:
-        chunks = chunk_text(text, document_id)
+        chunks = chunk_text(text, document_id, chat_id=chat_id)
+        logger.info("Chunking complete — chunk_count=%d", len(chunks))
         vectors = embed_chunks(chunks)
+        logger.info("Embedding complete — vector_count=%d", len(vectors))
         count = upsert_to_store(chunks, vectors)
+        logger.info("Upsert complete — upserted_count=%d", count)
     except Exception as exc:
+        logger.error("Ingestion pipeline failed — error=%s", exc)
         raise HTTPException(status_code=500, detail=f"Ingestion pipeline failed: {exc}") from exc
 
     return IngestResponse(document_id=document_id, chunks_created=count)

--- a/api/services/llm.py
+++ b/api/services/llm.py
@@ -2,12 +2,15 @@
 """LLM service — builds a prompt from retrieved context and calls the chat model."""
 
 import asyncio
+import logging
 
 import anthropic
 import openai
 
 from shared.config import ANTHROPIC_API_KEY, OLLAMA_URL, OPENAI_API_KEY
 from shared.models import ChatTurn, RetrievedChunk
+
+logger = logging.getLogger(__name__)
 
 # Models that are served locally via Ollama
 _KNOWN_OLLAMA_MODELS = {
@@ -30,20 +33,22 @@ _KNOWN_OLLAMA_MODELS = {
 
 
 def _build_system_prompt(context_chunks: list[RetrievedChunk]) -> str:
-    """Construct the system prompt that injects retrieved context."""
+    """Construct the system prompt, injecting retrieved context when available."""
     if not context_chunks:
-        context_text = "No relevant context was found in the knowledge base."
-    else:
-        sections = []
-        for i, rc in enumerate(context_chunks, start=1):
-            sections.append(f"[{i}] {rc.chunk.content}")
-        context_text = "\n\n".join(sections)
+        return (
+            "You are a helpful, knowledgeable assistant. "
+            "Answer the user's question thoroughly and accurately using your own knowledge."
+        )
+
+    sections = [f"[{i}] {rc.chunk.content}" for i, rc in enumerate(context_chunks, start=1)]
+    context_text = "\n\n".join(sections)
 
     return (
-        "You are a helpful assistant. Answer the user's question using only the "
-        "context below. If the context does not contain enough information to answer, "
-        "say so clearly.\n\n"
-        f"Context:\n{context_text}"
+        "You are a helpful, knowledgeable assistant. "
+        "Use the document context below to ground your answer with specific information from the user's documents. "
+        "You may also draw on your own knowledge to provide complete, accurate responses. "
+        "Always prioritise information from the context when it is relevant.\n\n"
+        f"Document context:\n{context_text}"
     )
 
 
@@ -93,10 +98,20 @@ async def generate_answer(
         The LLM-generated answer.
     """
     system_prompt = _build_system_prompt(context_chunks)
+    messages = _build_messages(query, system_prompt, chat_history)
+    logger.debug(
+        "Prompt built — system_prompt_length=%d message_count=%d",
+        len(system_prompt),
+        len(messages),
+    )
     loop = asyncio.get_event_loop()
 
     # --- Provider routing ---
     if model.startswith("claude-"):
+        effective_key = api_key or ANTHROPIC_API_KEY
+        if not effective_key:
+            logger.warning("Anthropic API key is empty — request will likely fail")
+        logger.info("Provider selected — provider=anthropic model=%s", model)
         return await loop.run_in_executor(
             None,
             _call_anthropic,
@@ -104,7 +119,7 @@ async def generate_answer(
             system_prompt,
             chat_history,
             model,
-            api_key or ANTHROPIC_API_KEY,
+            effective_key,
         )
 
     is_known_ollama = model in _KNOWN_OLLAMA_MODELS
@@ -112,6 +127,7 @@ async def generate_answer(
     use_ollama = is_known_ollama or (OLLAMA_URL and is_not_openai)
 
     if use_ollama:
+        logger.info("Provider selected — provider=ollama model=%s", model)
         effective_url = f"{api_url.rstrip('/')}/v1" if api_url else f"{OLLAMA_URL}/v1"
         return await loop.run_in_executor(
             None,
@@ -125,6 +141,10 @@ async def generate_answer(
         )
 
     # Default: OpenAI
+    effective_key = api_key or OPENAI_API_KEY
+    if not effective_key:
+        logger.warning("OpenAI API key is empty — request will likely fail")
+    logger.info("Provider selected — provider=openai model=%s", model)
     return await loop.run_in_executor(
         None,
         _call_openai_compat,
@@ -133,7 +153,7 @@ async def generate_answer(
         chat_history,
         model,
         None,
-        api_key or OPENAI_API_KEY,
+        effective_key,
     )
 
 

--- a/api/services/retriever.py
+++ b/api/services/retriever.py
@@ -2,9 +2,11 @@
 """Retriever service — queries Qdrant for relevant document chunks."""
 
 import asyncio
+import logging
 
 import openai
 from qdrant_client import QdrantClient
+from qdrant_client.models import FieldCondition, Filter, MatchValue
 
 from shared.config import (
     EMBEDDING_PROVIDER,
@@ -17,6 +19,8 @@ from shared.config import (
 )
 from shared.models import DocumentChunk, RetrievedChunk
 
+logger = logging.getLogger(__name__)
+
 
 def _embedding_client() -> tuple[openai.OpenAI, str]:
     """Return (client, model) for the configured embedding provider."""
@@ -28,7 +32,7 @@ def _embedding_client() -> tuple[openai.OpenAI, str]:
     return openai.OpenAI(api_key=OPENAI_API_KEY), OPENAI_EMBEDDING_MODEL
 
 
-async def retrieve(query: str, top_k: int = 5) -> list[RetrievedChunk]:
+async def retrieve(query: str, top_k: int = 5, chat_id: str | None = None) -> list[RetrievedChunk]:
     """Embed *query* and return the top-k most relevant chunks from the vector store.
 
     Embeds the query using the configured embedding provider (OpenAI or Ollama),
@@ -51,6 +55,7 @@ async def retrieve(query: str, top_k: int = 5) -> list[RetrievedChunk]:
 
     # Embed the query (blocking I/O — run in thread pool)
     emb_client, emb_model = _embedding_client()
+    logger.debug("Embedding query — model=%s", emb_model)
 
     def _embed() -> list[float]:
         response = emb_client.embeddings.create(
@@ -63,13 +68,23 @@ async def retrieve(query: str, top_k: int = 5) -> list[RetrievedChunk]:
 
     # Search Qdrant (blocking I/O — run in thread pool)
     qdrant = QdrantClient(url=QDRANT_URL)
+    logger.debug(
+        "Searching Qdrant — collection=%s top_k=%d chat_id=%s",
+        QDRANT_COLLECTION,
+        top_k,
+        chat_id,
+    )
 
     def _search() -> list:
+        query_filter = Filter(
+            must=[FieldCondition(key="metadata.chat_id", match=MatchValue(value=chat_id))]
+        ) if chat_id else None
         response = qdrant.query_points(
             collection_name=QDRANT_COLLECTION,
             query=query_vector,
             limit=top_k,
             with_payload=True,
+            query_filter=query_filter,
         )
         return response.points
 
@@ -80,4 +95,5 @@ async def retrieve(query: str, top_k: int = 5) -> list[RetrievedChunk]:
         chunk = DocumentChunk(**point.payload)
         retrieved.append(RetrievedChunk(chunk=chunk, score=point.score))
 
+    logger.info("Retrieval returned %d result(s)", len(retrieved))
     return retrieved

--- a/app/main.py
+++ b/app/main.py
@@ -43,7 +43,7 @@ CHATS_DIR: Path = Path(__file__).resolve().parent.parent / "chats"
 CHATS_DIR.mkdir(exist_ok=True)
 
 AVAILABLE_MODELS: dict[str, list[str]] = {
-    "OpenAI": ["gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"],
+    "OpenAI": ["gpt-5.4", "gpt-5.4-mini", "gpt-5.2", "gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"],
     "Anthropic": ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"],
     "Ollama": ["minimax-m2.7:cloud", "llama3.2", "llama3.1", "llama3", "mistral", "gemma2", "phi3", "codellama"],
 }
@@ -141,6 +141,7 @@ def call_chat_api(
     chat_history: list[dict[str, str]] | None = None,
     api_key: str | None = None,
     api_url: str | None = None,
+    chat_id: str | None = None,
 ) -> tuple[str, list[dict[str, Any]], str | None]:
     """POST to /chat/ and return (answer, sources, response_model).
 
@@ -165,6 +166,7 @@ def call_chat_api(
         "chat_history": chat_history or [],
         "api_key": api_key or None,
         "api_url": api_url or None,
+        "chat_id": chat_id or None,
     }
     with httpx.Client(timeout=60.0) as client:
         response = client.post(f"{API_URL}/chat/", json=payload)
@@ -176,9 +178,45 @@ def call_chat_api(
     return answer, sources, response_model
 
 
+def call_ingest_api(file_bytes: bytes, filename: str, document_id: str, chat_id: str = "") -> dict:
+    """POST a document to /ingest/ and return the IngestResponse dict."""
+    with httpx.Client(timeout=120.0) as client:
+        response = client.post(
+            f"{API_URL}/ingest/",
+            files={"file": (filename, file_bytes, "application/octet-stream")},
+            data={"document_id": document_id, "chat_id": chat_id},
+        )
+        response.raise_for_status()
+    return response.json()
+
+
 # ---------------------------------------------------------------------------
 # UI components
 # ---------------------------------------------------------------------------
+
+
+def render_upload_panel() -> None:
+    """Render the document upload section inside the sidebar."""
+    st.subheader("Upload Document")
+    uploaded = st.file_uploader(
+        "Choose a file",
+        type=["pdf", "txt", "md", "docx", "xlsx", "xls"],
+        key="_doc_uploader",
+    )
+    if uploaded:
+        default_id = Path(uploaded.name).stem
+        doc_id = st.text_input("Document ID", value=default_id, key="_doc_id")
+        if st.button("Ingest", use_container_width=True, key="_ingest_btn"):
+            with st.spinner(f"Ingesting {uploaded.name}..."):
+                try:
+                    result = call_ingest_api(uploaded.read(), uploaded.name, doc_id, chat_id=st.session_state.chat_id or "")
+                    st.success(f"Done — {result['chunks_created']} chunks created.")
+                except httpx.ConnectError:
+                    st.error("Cannot reach the API.")
+                except httpx.HTTPStatusError as exc:
+                    st.error(f"Ingest failed: {exc.response.text[:200]}")
+                except Exception as exc:
+                    st.error(f"Unexpected error: {exc}")
 
 
 def render_sidebar() -> None:
@@ -228,7 +266,7 @@ def render_sidebar() -> None:
         if selected_provider == "Ollama":
             st.session_state.provider_api_url = st.text_input(
                 "Ollama URL",
-                value=st.session_state.provider_api_url or "http://localhost:11434",
+                value=st.session_state.provider_api_url or "http://host.docker.internal:11434",
                 key="_ollama_url",
             )
             st.session_state.provider_api_key = ""
@@ -249,6 +287,11 @@ def render_sidebar() -> None:
         if st.button("+ New chat", use_container_width=True):
             _start_new_chat()
             st.rerun()
+
+        st.divider()
+
+        # --- Document upload ---
+        render_upload_panel()
 
         st.divider()
 
@@ -377,6 +420,7 @@ def _handle_user_input(user_input: str) -> None:
                     chat_history=list(st.session_state.messages[:-1]),
                     api_key=st.session_state.provider_api_key or None,
                     api_url=st.session_state.provider_api_url or None,
+                    chat_id=st.session_state.chat_id,
                 )
             except httpx.ConnectError:
                 st.error(

--- a/ingestion/chunker.py
+++ b/ingestion/chunker.py
@@ -1,9 +1,13 @@
 # ingestion/chunker.py
 """Text chunking — splits raw text into overlapping chunks for embedding."""
 
+import logging
+
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 from shared.models import DocumentChunk
+
+logger = logging.getLogger(__name__)
 
 
 def chunk_text(
@@ -11,6 +15,7 @@ def chunk_text(
     document_id: str,
     chunk_size: int = 512,
     chunk_overlap: int = 64,
+    chat_id: str = "",
 ) -> list[DocumentChunk]:
     """Split *text* into chunks and return a list of ``DocumentChunk`` objects.
 
@@ -34,17 +39,20 @@ def chunk_text(
     list[DocumentChunk]
         Ordered list of chunks.
     """
+    logger.info("Chunking text — input_length=%d", len(text))
     splitter = RecursiveCharacterTextSplitter(
         chunk_size=chunk_size,
         chunk_overlap=chunk_overlap,
     )
     texts = splitter.split_text(text)
-    return [
+    chunks = [
         DocumentChunk(
             chunk_id=f"{document_id}-{i}",
             document_id=document_id,
             content=chunk_text,
-            metadata={"chunk_index": i},
+            metadata={"chunk_index": i, "chat_id": chat_id},
         )
         for i, chunk_text in enumerate(texts)
     ]
+    logger.info("Chunking complete — chunk_count=%d", len(chunks))
+    return chunks

--- a/ingestion/embedder.py
+++ b/ingestion/embedder.py
@@ -1,6 +1,8 @@
 # ingestion/embedder.py
 """Embedding pipeline — converts text chunks into vectors and upserts to Qdrant."""
 
+import logging
+
 import openai
 from qdrant_client import QdrantClient
 from qdrant_client.models import Distance, PointStruct, VectorParams
@@ -16,6 +18,8 @@ from shared.config import (
     VECTOR_SIZE,
 )
 from shared.models import DocumentChunk
+
+logger = logging.getLogger(__name__)
 
 
 def _embedding_client() -> tuple[openai.OpenAI, str]:
@@ -44,6 +48,7 @@ def embed_chunks(chunks: list[DocumentChunk]) -> list[list[float]]:
         A list of embedding vectors, one per chunk, in the same order.
     """
     client, model = _embedding_client()
+    logger.info("Embedding chunks — chunk_count=%d provider=%s", len(chunks), EMBEDDING_PROVIDER)
     response = client.embeddings.create(
         model=model,
         input=[c.content for c in chunks],
@@ -88,4 +93,5 @@ def upsert_to_store(chunks: list[DocumentChunk], vectors: list[list[float]]) -> 
     ]
 
     qdrant.upsert(collection_name=QDRANT_COLLECTION, points=points)
+    logger.info("Upsert complete — upserted_count=%d collection=%s", len(points), QDRANT_COLLECTION)
     return len(points)

--- a/ingestion/loader.py
+++ b/ingestion/loader.py
@@ -1,9 +1,12 @@
 # ingestion/loader.py
 """Document loading — reads raw files and returns plain text."""
 
+import logging
 from pathlib import Path
 
 from langchain_community.document_loaders import PyPDFLoader, TextLoader
+
+logger = logging.getLogger(__name__)
 
 
 def load_document(file_path: Path) -> str:
@@ -24,15 +27,33 @@ def load_document(file_path: Path) -> str:
     """
     file_path = Path(file_path)
     suffix = file_path.suffix.lower()
+    logger.info("Loading document — path=%s extension=%s", file_path, suffix)
 
     if suffix == ".pdf":
         loader = PyPDFLoader(str(file_path))
+        docs = loader.load()
+        text = "\n".join(doc.page_content for doc in docs)
     elif suffix in {".txt", ".md"}:
         loader = TextLoader(str(file_path), encoding="utf-8")
+        docs = loader.load()
+        text = "\n".join(doc.page_content for doc in docs)
+    elif suffix == ".docx":
+        import docx2txt
+        text = docx2txt.process(str(file_path))
+    elif suffix in {".xlsx", ".xls"}:
+        import openpyxl
+        wb = openpyxl.load_workbook(file_path, read_only=True, data_only=True)
+        parts = []
+        for sheet in wb.worksheets:
+            parts.append(f"Sheet: {sheet.title}")
+            for row in sheet.iter_rows(values_only=True):
+                parts.append("\t".join("" if c is None else str(c) for c in row))
+        wb.close()
+        text = "\n".join(parts)
     else:
         raise ValueError(
-            f"Unsupported file type: {suffix!r}. Supported: .pdf, .txt, .md"
+            f"Unsupported file type: {suffix!r}. Supported: .pdf, .txt, .md, .docx, .xlsx, .xls"
         )
 
-    docs = loader.load()
-    return "\n".join(doc.page_content for doc in docs)
+    logger.info("Document loaded — text_length=%d", len(text))
+    return text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,15 @@ dependencies = [
     "langchain-text-splitters>=0.3.0",
     "pypdf>=5.0.0",
     "anthropic>=0.40.0",
+    "docx2txt>=0.8",
+    "openpyxl>=3.1.0",
 ]
 
 [dependency-groups]
 dev = [
     "pytest>=8.3.0",
     "pytest-asyncio>=0.25.0",
+    "pytest-cov>=6.0.0",
     "httpx>=0.28.0",
 ]
 

--- a/shared/models.py
+++ b/shared/models.py
@@ -56,6 +56,7 @@ class ChatRequest(BaseModel):
     )
     api_key: str | None = Field(default=None, description="Provider API key (overrides env var)")
     api_url: str | None = Field(default=None, description="Provider base URL override (used for Ollama)")
+    chat_id: str | None = Field(default=None, description="Active chat session ID for document scoping")
 
 
 class ChatResponse(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,7 @@
 # tests/conftest.py
 """Shared pytest fixtures for the entire test suite."""
 
-import asyncio
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -114,31 +113,3 @@ def mock_anthropic_client() -> MagicMock:
     return client
 
 
-@pytest.fixture()
-def mock_qdrant_client() -> MagicMock:
-    """Mock Qdrant client with in-memory behavior."""
-    client = MagicMock()
-
-    # Mock get_collections
-    mock_collection = MagicMock()
-    mock_collection.name = "documents"
-    client.get_collections.return_value.collections = [mock_collection]
-
-    # Mock search results
-    def mock_search(collection_name, query_vector, limit, with_payload=False):
-        # Return a mock search result
-        mock_point = MagicMock()
-        mock_point.payload = {
-            "chunk_id": "doc-1-0",
-            "document_id": "doc-1",
-            "content": "Sample retrieved chunk.",
-            "metadata": {"page": 1},
-        }
-        mock_point.score = 0.95
-        return [mock_point]
-
-    client.search.side_effect = mock_search
-    client.upsert.return_value = None
-    client.create_collection.return_value = None
-
-    return client

--- a/tests/contract/__init__.py
+++ b/tests/contract/__init__.py
@@ -1,1 +1,0 @@
-# tests/contract/__init__.py

--- a/tests/integration/test_chat_endpoint.py
+++ b/tests/integration/test_chat_endpoint.py
@@ -1,21 +1,13 @@
 # tests/integration/test_chat_endpoint.py
 """Integration tests for the /chat endpoint."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 from api.main import app
 from shared.models import DocumentChunk, RetrievedChunk
-
-
-@pytest.fixture
-def async_client():
-    """Return an async test client for FastAPI."""
-    from httpx import AsyncClient
-
-    return AsyncClient(app=app, base_url="http://test")
 
 
 class TestChatEndpointBasic:
@@ -147,18 +139,21 @@ class TestChatEndpointValidation:
 class TestChatEndpointErrorHandling:
     """Tests for error handling in chat endpoint."""
 
-    def test_chat_endpoint_retrieval_failure_returns_502(self, client) -> None:
-        """POST /chat/ returns 502 if retrieval fails."""
+    def test_chat_endpoint_retrieval_failure_continues_without_context(self, client) -> None:
+        """POST /chat/ continues with empty chunks if retrieval fails."""
         request = {"query": "Test?", "top_k": 5}
 
-        with patch("api.routes.chat.retrieve") as mock_retrieve:
+        with patch("api.routes.chat.retrieve") as mock_retrieve, patch(
+            "api.routes.chat.generate_answer"
+        ) as mock_generate:
             mock_retrieve.side_effect = Exception("Qdrant unavailable")
+            mock_generate.return_value = "Answer without context"
 
             response = client.post("/chat/", json=request)
 
-            assert response.status_code == 502
+            assert response.status_code == 200
             data = response.json()
-            assert "Retrieval failed" in data.get("detail", "")
+            assert data["sources"] == []
 
     def test_chat_endpoint_llm_failure_returns_502(self, client) -> None:
         """POST /chat/ returns 502 if LLM generation fails."""

--- a/tests/integration/test_ingest_endpoint.py
+++ b/tests/integration/test_ingest_endpoint.py
@@ -1,10 +1,7 @@
 # tests/integration/test_ingest_endpoint.py
 """Integration tests for the /ingest endpoint."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
-from io import BytesIO
-import tempfile
-from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient

--- a/tests/integration/test_pipeline_integration.py
+++ b/tests/integration/test_pipeline_integration.py
@@ -2,8 +2,6 @@
 """End-to-end integration tests for the complete RAG pipeline."""
 
 from unittest.mock import MagicMock, patch
-import tempfile
-from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -80,19 +78,22 @@ class TestErrorPropagation:
             assert response.status_code == 422
             assert "Unsupported file type" in response.json().get("detail", "")
 
-    def test_chat_retrieval_error_returns_502(self) -> None:
-        """Chat endpoint returns 502 when retrieval fails."""
+    def test_chat_retrieval_error_continues_without_context(self) -> None:
+        """Chat endpoint continues with empty context when retrieval fails."""
         client = TestClient(app)
 
         request = {"query": "Test?", "top_k": 5}
 
-        with patch("api.routes.chat.retrieve") as mock_retrieve:
+        with patch("api.routes.chat.retrieve") as mock_retrieve, patch(
+            "api.routes.chat.generate_answer"
+        ) as mock_generate:
             mock_retrieve.side_effect = RuntimeError("Qdrant unreachable")
+            mock_generate.return_value = "Answer without context"
 
             response = client.post("/chat/", json=request)
 
-            assert response.status_code == 502
-            assert "Retrieval failed" in response.json()["detail"]
+            assert response.status_code == 200
+            assert response.json()["sources"] == []
 
     def test_chat_generation_error_returns_502(self) -> None:
         """Chat endpoint returns 502 when LLM generation fails."""

--- a/tests/unit/test_embedder.py
+++ b/tests/unit/test_embedder.py
@@ -67,6 +67,8 @@ class TestEmbedChunks:
             "ingestion.embedder.openai.OpenAI"
         ) as mock_openai, patch(
             "ingestion.embedder.OPENAI_EMBEDDING_MODEL", "text-embedding-3-small"
+        ), patch(
+            "ingestion.embedder.EMBEDDING_PROVIDER", "openai"
         ):
             client_instance = MagicMock()
             mock_openai.return_value = client_instance

--- a/tests/unit/test_embedder_advanced.py
+++ b/tests/unit/test_embedder_advanced.py
@@ -2,7 +2,6 @@
 """Advanced unit tests for the embedding module."""
 
 from unittest.mock import MagicMock, patch
-import pytest
 
 from ingestion.embedder import embed_chunks, upsert_to_store
 from shared.models import DocumentChunk

--- a/tests/unit/test_llm_routing.py
+++ b/tests/unit/test_llm_routing.py
@@ -1,8 +1,7 @@
 # tests/unit/test_llm_routing.py
 """Unit tests for LLM provider routing logic."""
 
-from unittest.mock import MagicMock, patch, AsyncMock
-import asyncio
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -21,7 +20,7 @@ class TestBuildSystemPrompt:
 
         prompt = _build_system_prompt(retrieved)
 
-        assert "You are a helpful assistant" in prompt
+        assert "You are a helpful" in prompt
         assert "context" in prompt.lower()
         # Check that chunk content is included
         for chunk in sample_chunks:
@@ -31,8 +30,8 @@ class TestBuildSystemPrompt:
         """System prompt handles empty context gracefully."""
         prompt = _build_system_prompt([])
 
-        assert "You are a helpful assistant" in prompt
-        assert "No relevant context" in prompt
+        assert "You are a helpful" in prompt
+        assert "your own knowledge" in prompt
 
     def test_build_system_prompt_multiple_chunks(self, sample_chunks) -> None:
         """System prompt includes all chunks with numbered sections."""

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -112,8 +112,8 @@ class TestLoadDocumentErrors:
 
     def test_unsupported_extension_raises_value_error(self) -> None:
         """Loading an unsupported file type raises ValueError."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".docx", delete=False) as f:
-            f.write("This file type is not supported.")
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write("col1,col2\nval1,val2")
             f.flush()
             temp_path = f.name
 

--- a/tests/unit/test_retriever.py
+++ b/tests/unit/test_retriever.py
@@ -1,12 +1,19 @@
 # tests/unit/test_retriever.py
 """Unit tests for the retriever service."""
 
-from unittest.mock import MagicMock, patch, AsyncMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from api.services.retriever import retrieve
 from shared.models import DocumentChunk, RetrievedChunk
+
+
+def _mock_qdrant_response(points):
+    """Return a MagicMock that mimics query_points() response."""
+    mock_response = MagicMock()
+    mock_response.points = points
+    return mock_response
 
 
 class TestRetrieveBasic:
@@ -36,7 +43,7 @@ class TestRetrieveBasic:
                 "metadata": {},
             }
             mock_point.score = 0.95
-            qdrant_instance.search.return_value = [mock_point]
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([mock_point])
 
             result = await retrieve("Test query", top_k=5)
 
@@ -59,7 +66,7 @@ class TestRetrieveBasic:
 
             qdrant_instance = MagicMock()
             mock_qdrant.return_value = qdrant_instance
-            qdrant_instance.search.return_value = []
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([])
 
             await retrieve("Test query", top_k=5)
 
@@ -83,14 +90,14 @@ class TestRetrieveBasic:
 
             qdrant_instance = MagicMock()
             mock_qdrant.return_value = qdrant_instance
-            qdrant_instance.search.return_value = []
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([])
 
             await retrieve("Test query", top_k=10)
 
-            # Verify Qdrant search was called
-            qdrant_instance.search.assert_called_once()
-            call_kwargs = qdrant_instance.search.call_args.kwargs
-            assert call_kwargs.get("query_vector") == test_vector
+            # Verify Qdrant query_points was called
+            qdrant_instance.query_points.assert_called_once()
+            call_kwargs = qdrant_instance.query_points.call_args.kwargs
+            assert call_kwargs.get("query") == test_vector
             assert call_kwargs.get("limit") == 10
 
     @pytest.mark.asyncio
@@ -107,11 +114,11 @@ class TestRetrieveBasic:
 
             qdrant_instance = MagicMock()
             mock_qdrant.return_value = qdrant_instance
-            qdrant_instance.search.return_value = []
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([])
 
             await retrieve("Query", top_k=20)
 
-            call_kwargs = qdrant_instance.search.call_args.kwargs
+            call_kwargs = qdrant_instance.query_points.call_args.kwargs
             assert call_kwargs.get("limit") == 20
 
 
@@ -132,7 +139,7 @@ class TestRetrieveEdgeCases:
 
             qdrant_instance = MagicMock()
             mock_qdrant.return_value = qdrant_instance
-            qdrant_instance.search.return_value = []  # No results
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([])
 
             result = await retrieve("Obscure query", top_k=5)
 
@@ -166,7 +173,7 @@ class TestRetrieveEdgeCases:
                 mock_point.score = 0.9 - (i * 0.05)  # Decreasing scores
                 mock_points.append(mock_point)
 
-            qdrant_instance.search.return_value = mock_points
+            qdrant_instance.query_points.return_value = _mock_qdrant_response(mock_points)
 
             result = await retrieve("Query", top_k=5)
 
@@ -198,7 +205,7 @@ class TestRetrieveEdgeCases:
                 "metadata": {},
             }
             mock_point.score = 0.1  # Very low score
-            qdrant_instance.search.return_value = [mock_point]
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([mock_point])
 
             result = await retrieve("Query", top_k=1)
 
@@ -217,6 +224,9 @@ class TestRetrieveConfiguration:
         ) as mock_qdrant, patch(
             "api.services.retriever.OPENAI_EMBEDDING_MODEL",
             "text-embedding-3-small",
+        ), patch(
+            "api.services.retriever.EMBEDDING_PROVIDER",
+            "openai",
         ):
             oai_instance = MagicMock()
             mock_openai.return_value = oai_instance
@@ -226,7 +236,7 @@ class TestRetrieveConfiguration:
 
             qdrant_instance = MagicMock()
             mock_qdrant.return_value = qdrant_instance
-            qdrant_instance.search.return_value = []
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([])
 
             await retrieve("Query", top_k=5)
 
@@ -249,11 +259,11 @@ class TestRetrieveConfiguration:
 
             qdrant_instance = MagicMock()
             mock_qdrant.return_value = qdrant_instance
-            qdrant_instance.search.return_value = []
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([])
 
             await retrieve("Query", top_k=5)
 
-            call_kwargs = qdrant_instance.search.call_args.kwargs
+            call_kwargs = qdrant_instance.query_points.call_args.kwargs
             assert call_kwargs.get("collection_name") == "my-documents"
 
 
@@ -284,7 +294,7 @@ class TestRetrieveChunkIntegrity:
                 "metadata": {"source": "user_upload"},
             }
             mock_point.score = 0.95
-            qdrant_instance.search.return_value = [mock_point]
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([mock_point])
 
             result = await retrieve("Query", top_k=5)
 
@@ -314,7 +324,7 @@ class TestRetrieveChunkIntegrity:
                 "metadata": metadata,
             }
             mock_point.score = 0.95
-            qdrant_instance.search.return_value = [mock_point]
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([mock_point])
 
             result = await retrieve("Query", top_k=5)
 

--- a/tests/unit/test_retriever_advanced.py
+++ b/tests/unit/test_retriever_advanced.py
@@ -1,11 +1,18 @@
 # tests/unit/test_retriever_advanced.py
 """Advanced unit tests for the retriever service."""
 
-from unittest.mock import MagicMock, patch, AsyncMock
+from unittest.mock import MagicMock, patch
 import pytest
 
 from api.services.retriever import retrieve
 from shared.models import DocumentChunk, RetrievedChunk
+
+
+def _mock_qdrant_response(points):
+    """Return a MagicMock that mimics query_points() response."""
+    mock_response = MagicMock()
+    mock_response.points = points
+    return mock_response
 
 
 class TestRetrieveAdvanced:
@@ -25,7 +32,7 @@ class TestRetrieveAdvanced:
 
             qdrant_instance = MagicMock()
             mock_qdrant.return_value = qdrant_instance
-            qdrant_instance.search.return_value = []
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([])
 
             result = await retrieve("你好 مرحبا café", top_k=5)
 
@@ -50,7 +57,7 @@ class TestRetrieveAdvanced:
 
             qdrant_instance = MagicMock()
             mock_qdrant.return_value = qdrant_instance
-            qdrant_instance.search.return_value = []
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([])
 
             result = await retrieve(long_query, top_k=5)
 
@@ -74,7 +81,7 @@ class TestRetrieveAdvanced:
 
             qdrant_instance = MagicMock()
             mock_qdrant.return_value = qdrant_instance
-            qdrant_instance.search.return_value = []
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([])
 
             result = await retrieve(special_query, top_k=5)
 
@@ -111,7 +118,7 @@ class TestRetrieveAdvanced:
             mock_point = MagicMock()
             mock_point.payload = payload
             mock_point.score = 0.87
-            qdrant_instance.search.return_value = [mock_point]
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([mock_point])
 
             result = await retrieve("Query", top_k=5)
 
@@ -137,17 +144,18 @@ class TestRetrieveAdvanced:
 
             qdrant_instance = MagicMock()
             mock_qdrant.return_value = qdrant_instance
-            qdrant_instance.search.return_value = []
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([])
 
             # Test with top_k = 1 (minimum)
             await retrieve("Query", top_k=1)
-            call_kwargs = qdrant_instance.search.call_args.kwargs
+            call_kwargs = qdrant_instance.query_points.call_args.kwargs
             assert call_kwargs["limit"] == 1
 
             # Test with top_k = 100 (large)
             qdrant_instance.reset_mock()
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([])
             await retrieve("Query", top_k=100)
-            call_kwargs = qdrant_instance.search.call_args.kwargs
+            call_kwargs = qdrant_instance.query_points.call_args.kwargs
             assert call_kwargs["limit"] == 100
 
     @pytest.mark.asyncio
@@ -178,7 +186,7 @@ class TestRetrieveAdvanced:
                 mock_point.score = score
                 mock_points.append(mock_point)
 
-            qdrant_instance.search.return_value = mock_points
+            qdrant_instance.query_points.return_value = _mock_qdrant_response(mock_points)
 
             result = await retrieve("Query", top_k=5)
 
@@ -212,7 +220,7 @@ class TestRetrieveAdvanced:
             mock_point = MagicMock()
             mock_point.payload = payload
             mock_point.score = 0.95
-            qdrant_instance.search.return_value = [mock_point]
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([mock_point])
 
             result = await retrieve("Query", top_k=5)
 
@@ -236,13 +244,13 @@ class TestRetrieveAdvanced:
 
             qdrant_instance = MagicMock()
             mock_qdrant.return_value = qdrant_instance
-            qdrant_instance.search.return_value = []
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([])
 
             await retrieve("Query", top_k=5)
 
-            # Verify the exact vector was passed to search
-            call_kwargs = qdrant_instance.search.call_args.kwargs
-            assert call_kwargs["query_vector"] == distinctive_vector
+            # Verify the exact vector was passed to query_points
+            call_kwargs = qdrant_instance.query_points.call_args.kwargs
+            assert call_kwargs["query"] == distinctive_vector
 
     @pytest.mark.asyncio
     async def test_retrieve_constructs_retrieved_chunks_correctly(self) -> None:
@@ -267,7 +275,7 @@ class TestRetrieveAdvanced:
                 "metadata": {}
             }
             mock_point.score = 0.95
-            qdrant_instance.search.return_value = [mock_point]
+            qdrant_instance.query_points.return_value = _mock_qdrant_response([mock_point])
 
             result = await retrieve("Query", top_k=5)
 

--- a/uv.lock
+++ b/uv.lock
@@ -322,17 +322,103 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
 name = "custom-rag"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "docx2txt" },
     { name = "fastapi" },
     { name = "langchain" },
     { name = "langchain-community" },
     { name = "langchain-openai" },
     { name = "langchain-text-splitters" },
     { name = "openai" },
+    { name = "openpyxl" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pypdf" },
@@ -348,17 +434,20 @@ dev = [
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.40.0" },
+    { name = "docx2txt", specifier = ">=0.8" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "langchain", specifier = ">=0.3.0" },
     { name = "langchain-community", specifier = ">=0.3.0" },
     { name = "langchain-openai", specifier = ">=0.3.0" },
     { name = "langchain-text-splitters", specifier = ">=0.3.0" },
     { name = "openai", specifier = ">=1.68.0" },
+    { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "pydantic-settings", specifier = ">=2.8.0" },
     { name = "pypdf", specifier = ">=5.0.0" },
@@ -374,6 +463,7 @@ dev = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "pytest", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", specifier = ">=0.25.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
 ]
 
 [[package]]
@@ -405,6 +495,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "docx2txt"
+version = "0.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/07/4486a038624e885e227fe79111914c01f55aa70a51920ff1a7f2bd216d10/docx2txt-0.9.tar.gz", hash = "sha256:18013f6229b14909028b19aa7bf4f8f3d6e4632d7b089ab29f7f0a4d1f660e28", size = 3613, upload-time = "2025-03-24T20:59:25.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/51/756e71bec48ece0ecc2a10e921ef2756e197dcb7e478f2b43673b6683902/docx2txt-0.9-py3-none-any.whl", hash = "sha256:e3718c0653fd6f2fcf4b51b02a61452ad1c38a4c163bcf0a6fd9486cd38f529a", size = 4025, upload-time = "2025-03-24T20:59:24.394Z" },
+]
+
+[[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
 ]
 
 [[package]]
@@ -1322,6 +1430,18 @@ wheels = [
 ]
 
 [[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1859,6 +1979,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
…pport

Chat scoping:
- Added chat_id field to ChatRequest for per-session document filtering
- Retriever now filters Qdrant queries by chat_id metadata
- Ingest endpoint accepts chat_id and stores it in chunk metadata
- UI wires chat_id through all API calls

Document upload UI:
- Added sidebar upload panel for PDF, TXT, MD, DOCX, XLSX files
- New call_ingest_api() function for document ingestion

New file format support:
- Added .docx loading via docx2txt
- Added .xlsx/.xls loading via openpyxl

Observability:
- Added structured logging throughout API, ingestion, and retriever
- Logs request params, chunk counts, provider selection, errors

LLM improvements:
- Updated system prompt to use own knowledge when no context found
- Graceful degradation: continue without context on retrieval failure

CI/CD:
- Added pytest + coverage job to PR workflow
- Coverage report included in Claude code review context

Dependencies:
- docx2txt>=0.8, openpyxl>=3.1.0, pytest-cov>=6.0.0